### PR TITLE
add prompt inputs when dropzones are clicked upon

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"log"
-
 	"jamdrop/config"
 	"jamdrop/db"
 	"jamdrop/logger"
@@ -21,11 +19,6 @@ type App struct {
 }
 
 func New(cfg *config.Config) (*App, error) {
-	logFlags := log.Lshortfile
-	if cfg.IsDevelopment() {
-		logFlags |= log.LstdFlags
-	}
-
 	logLevel := logger.Info
 	if cfg.IsDevelopment() {
 		logLevel = logger.Debug

--- a/frontend/js/add_share.js
+++ b/frontend/js/add_share.js
@@ -5,13 +5,22 @@ import toaster from "./toaster";
 export const AddShare = (vnode) => {
     const { reload } = vnode.attrs;
 
+    const addShare = (userIdentifier) => {
+        api.addShare(userIdentifier)
+            .then(reload)
+            .catch((e) => toaster.setError(e.response.error));
+    };
+
     const ondrop = (event) => {
         event.preventDefault();
         const userIdentifier = event.dataTransfer.getData('text/plain');
 
-        api.addShare(userIdentifier)
-            .then(reload)
-            .catch((e) => toaster.setError(e.response.error));
+        addShare(userIdentifier);
+    };
+
+    const onclick = () => {
+        const userIdentifier = window.prompt('Paste a Spotify user ID or link here to share your queue');
+        if (userIdentifier) addShare(userIdentifier);
     };
 
     const ondragover = (event) => {
@@ -21,7 +30,7 @@ export const AddShare = (vnode) => {
 
     return {
         view() {
-            return m('.add.share', { ondrop, ondragover }, m('p', 'drag a Spotify user here to share your queue'));
+            return m('.add.share', { ondrop, ondragover, onclick }, m('p', 'drag a Spotify user here to share your queue'));
         }
     };
 };

--- a/frontend/js/sharers.js
+++ b/frontend/js/sharers.js
@@ -34,14 +34,23 @@ export const Sharer = (vnode) => {
         event.dataTransfer.setData('text/plain', sharer.id);
     };
 
+    const queueSong = (songIdentifier) => {
+        api.queueSong(sharer.id, songIdentifier)
+            .then((res) => toaster.setMessage(res.message))
+            .catch((e) => toaster.setError(e.response.error));
+    };
+
     const ondrop = (event) => {
         event.preventDefault();
 
         const songIdentifier = event.dataTransfer.getData('text/plain');
 
-        api.queueSong(sharer.id, songIdentifier)
-            .then((res) => toaster.setMessage(res.message))
-            .catch((e) => toaster.setError(e.response.error));
+        queueSong(songIdentifier);
+    };
+
+    const onclick = () => {
+        const songIdentifier = window.prompt(`Paste a Spotify song ID or link here to drop it to ${sharer.name}'s queue`);
+        if (songIdentifier) queueSong(songIdentifier);
     };
 
     return {
@@ -63,7 +72,8 @@ export const Sharer = (vnode) => {
                     draggable: true,
                     ondragstart,
                     ondrop,
-                    ondragover
+                    ondragover,
+                    onclick
                 },
                 [
                     m('img.image', {src: sharer.image_url, draggable: false}),

--- a/frontend/scss/sharers.scss
+++ b/frontend/scss/sharers.scss
@@ -15,7 +15,7 @@
     align-items: center;
 
     &:hover {
-      cursor: grab;
+      cursor: copy;
     }
 
     &.disabled {


### PR DESCRIPTION
- Remove unnecessary log flag initialization
- Added browser text input prompts when dropzones are clicked on, so that users can paste IDs/links instead of always having to drag'n'drop for sharing. This should be be a temporary solution - it would be better to have the dropzone turn into a text input of some sort. Or maybe show a modal. Idk I'm not a designer.